### PR TITLE
イベントの時刻が表示されないバグを修正

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/example/project/data/db/Converters.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/data/db/Converters.kt
@@ -19,6 +19,6 @@ class Converters {
 
     @TypeConverter
     fun dateTimeToString(dateTime: LocalDateTime?): String? {
-        return dateTime?.date?.toString()
+        return dateTime?.toString()
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/example/project/ui/component/EventInfoArea.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/ui/component/EventInfoArea.kt
@@ -2,6 +2,7 @@ package org.example.project.ui.component
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable

--- a/composeApp/src/commonMain/kotlin/org/example/project/ui/component/EventInfoArea.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/ui/component/EventInfoArea.kt
@@ -2,14 +2,11 @@ package org.example.project.ui.component
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow.Companion.Ellipsis
-import androidx.compose.ui.unit.sp
 import org.jetbrains.compose.resources.stringResource
 import pickupconnpassevents.composeapp.generated.resources.Res
 import pickupconnpassevents.composeapp.generated.resources.event_item_location

--- a/composeApp/src/commonMain/kotlin/org/example/project/ui/event/EventUiState.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/ui/event/EventUiState.kt
@@ -32,7 +32,7 @@ data class EventItemUiState(
         val dayOfMonth = "/${this.dayOfMonth}"
 
         val hour = this.hour.toString()
-        val minute = this.minute.toString()
+        val minute = if (this.minute == 0) "00" else this.minute.toString()
 
         return "$year$monthNumber$dayOfMonth$dayOfWeek $hour:$minute"
     }


### PR DESCRIPTION
AndroidもiOSも時刻が表示されるようになりました。

| Android | iOS |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/d6708c69-d46e-4930-8e0a-99d30a0a3bd4" width="200">  | <img src="https://github.com/user-attachments/assets/ad8d4f35-2d42-40a2-982e-e921ca770189" width="200">  | 
